### PR TITLE
1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [1.6.1] - 2024-09-30
+- Fixed `clearable` not working in Select components.
+- Fixed `Tabs` tab alignment when in horizontal mode.
+- `OptionsPanel`, `OptionsPanelSection`, and `OptionsPanelHeader` now support the `hidden` prop.
+- Tweaked `OptionsPanelHeader` title font.
+- Tweaked some default Gutenberg overrides to do WP 6.6 changes.
+- Reverted `position: relative` overlap tweak by @piqusy, as it caused layout issues in some cases. `z-index: 50` should still make it OK.
+
 ## [1.6.0] - 2024-09-27
 - Updated dependencies.
 - `ColorPicker` now has better UX when set to `clearable`.
@@ -181,6 +189,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - Initial release
 
 [Unreleased]: https://github.com/infinum/eightshift-ui-components/compare/master...HEAD
+[1.6.1]: https://github.com/infinum/eightshift-ui-components/compare/1.6.0...1.6.1
 [1.6.0]: https://github.com/infinum/eightshift-ui-components/compare/1.5.1...1.6.0
 [1.5.1]: https://github.com/infinum/eightshift-ui-components/compare/1.5.0...1.5.1
 [1.5.0]: https://github.com/infinum/eightshift-ui-components/compare/1.4.7...1.5.0

--- a/lib/components/options-panel/options-panel.jsx
+++ b/lib/components/options-panel/options-panel.jsx
@@ -14,6 +14,7 @@ import { Heading } from 'react-aria-components';
  * @param {JSX.Element} [props.icon] - Icon to display on the top of the panel.
  * @param {string} [props.subtitle] - Subtitle to display on the top of the panel.
  * @param {string} [props.help] - Help text to show below the panel.
+ * @param {boolean} [props.hidden] - If `true`, the component is not rendered.
  *
  * @returns {JSX.Element} The OptionsPanel component.
  *
@@ -25,7 +26,11 @@ import { Heading } from 'react-aria-components';
  * @preserve
  */
 export const OptionsPanel = (props) => {
-	const { children, className, title, icon, subtitle, help } = props;
+	const { children, className, title, icon, subtitle, help, hidden } = props;
+
+	if (hidden) {
+		return null;
+	}
 
 	return (
 		<div className={clsx('es-uic-max-w-md', className)}>
@@ -49,6 +54,7 @@ export const OptionsPanel = (props) => {
  * @component
  * @param {Object} props - Component props.
  * @param {string} [props.className] - Classes to pass to the container.
+ * @param {boolean} [props.hidden] - If `true`, the component is not rendered.
  *
  * @returns {JSX.Element} The OptionsPanelSection component.
  *
@@ -59,7 +65,11 @@ export const OptionsPanel = (props) => {
  *
  * @preserve
  */
-export const OptionsPanelSection = ({ children, className }) => {
+export const OptionsPanelSection = ({ children, className, hidden }) => {
+	if (hidden) {
+		return null;
+	}
+
 	return (
 		<div
 			className={clsx(
@@ -82,6 +92,7 @@ export const OptionsPanelSection = ({ children, className }) => {
  * @param {Number} [props.level=2] - Heading level of the title.
  * @param {string} [props.className] - Classes to pass to the container.
  * @param {JSX.Element|JSX.Element[]} [props.actions] - Controls to show on the right side of the header.
+ * @param {boolean} [props.hidden] - If `true`, the component is not rendered.
  *
  * @returns {JSX.Element} The OptionsPanelHeader component.
  *
@@ -92,12 +103,16 @@ export const OptionsPanelSection = ({ children, className }) => {
  *
  * @preserve
  */
-export const OptionsPanelHeader = ({ children, sticky, title, className, actions, level = 2 }) => {
+export const OptionsPanelHeader = ({ children, sticky, title, className, actions, level = 2, hidden }) => {
+	if (hidden) {
+		return null;
+	}
+
 	return (
 		<div className={clsx('es-uic-max-w-md es-uic-space-y-2.5', sticky && 'es-uic-sticky es-uic-top-0 es-uic-z-10', className)}>
 			<div className='es-uic-flex es-uic-flex-wrap es-uic-items-center es-uic-justify-between es-uic-gap-x-8 es-uic-gap-y-4'>
 				<Heading
-					className='es-uic-text-3xl es-uic-font-medium es-uic-tracking-tighter'
+					className='es-uic-text-2xl es-uic-font-medium es-uic-tracking-tight'
 					level={level}
 				>
 					{title}

--- a/lib/components/select/async-single-select.jsx
+++ b/lib/components/select/async-single-select.jsx
@@ -116,7 +116,10 @@ export const AsyncSelect = (props) => {
 				defaultOptions={preloadOptions}
 				value={value}
 				onChange={(value) => {
-					delete value.id;
+					if (value && 'id' in value) {
+						delete value.id;
+					}
+
 					onChange(value);
 				}}
 				closeMenuOnSelect={!keepMenuOpenAfterSelect}

--- a/lib/components/select/single-select.jsx
+++ b/lib/components/select/single-select.jsx
@@ -109,7 +109,10 @@ export const Select = (props) => {
 						return;
 					}
 
-					delete v.id;
+					if (v && 'id' in v) {
+						delete v.id;
+					}
+
 					onChange(v);
 				}}
 				closeMenuOnSelect={!keepMenuOpenAfterSelect}

--- a/lib/components/select/styles.js
+++ b/lib/components/select/styles.js
@@ -19,7 +19,7 @@ const multiValueRemoveStyles =
 const clearIndicatorStyles = 'es-uic-text-gray-500 es-uic-p-1 es-uic-rounded-md hover:bg-red-50 hover:text-red-800 es-uic-transition';
 const dropdownIndicatorStyles =
 	'es-uic-text-gray-500 es-uic-px-1 group-hover:es-uic-text-black [&>svg]:es-uic-transition-transform [&>svg]:es-uic-duration-500 [&>svg]:es-uic-size-5.5';
-const menuStyles = 'es-uic-relative es-uic-z-50 es-uic-rounded-md es-uic-border es-uic-border-gray-200 es-uic-bg-white es-uic-shadow-lg es-uic-mt-1 es-uic-text-sm es-uic-overflow-x-hidden';
+const menuStyles = 'es-uic-z-50 es-uic-rounded-md es-uic-border es-uic-border-gray-200 es-uic-bg-white es-uic-shadow-lg es-uic-mt-1 es-uic-text-sm es-uic-overflow-x-hidden';
 const optionStyles = {
 	base: 'es-uic-p-2 !es-uic-flex es-uic-items-center es-uic-gap-1.5 es-uic-text-gray-800 es-uic-rounded [&>svg]:es-uic-size-5 [&>svg]:es-uic-text-gray-500 es-uic-transition es-uic-mx-1 first:es-uic-mt-1 last:es-uic-mb-1 !es-uic-w-auto es-uic-min-h-9',
 	focus: 'es-uic-bg-gray-100 active:es-uic-bg-teal-700/15',

--- a/lib/components/tabs/tabs.jsx
+++ b/lib/components/tabs/tabs.jsx
@@ -135,7 +135,7 @@ export const TabList = (props) => {
 				clsx(
 					'es-uic-flex',
 					orientation === 'vertical' && 'es-uic-h-full es-uic-flex-col es-uic-gap-px es-uic-pr-1.5',
-					orientation === 'horizontal' && 'es-uic-w-full es-uic-items-end es-uic-gap-1 es-uic-border-b es-uic-border-b-gray-300',
+					orientation === 'horizontal' && 'es-uic-w-full es-uic-items-stretch es-uic-gap-1 es-uic-border-b es-uic-border-b-gray-300',
 					className,
 				)
 			}

--- a/lib/wp/gutenberg-overrides.css
+++ b/lib/wp/gutenberg-overrides.css
@@ -57,21 +57,21 @@ button.components-toggle-group-control-option-base,
 	@apply !es-uic-w-80;
 }
 
-/* Fix block appender alignment */
-.block-list-appender.wp-block {
-	@apply !es-uic-static !es-uic-p-1;
-}
-
-.components-dropdown.block-editor-inserter {
-	@apply !es-uic-mx-auto !es-uic-w-fit;
-}
-
-/* Fix block appender alignment */
+/* Make block crash message nicer. */
 .block-editor-block-list__block-crash-warning {
 	@apply !es-uic-rounded-lg !es-uic-border-red-700/15 !es-uic-shadow !es-uic-shadow-red-700/10;
 
 	& .block-editor-warning__message {
 		@apply !es-uic-text-red-950;
+	}
+}
+
+/* Make block missing message nicer. */
+.block-editor-block-list__block.wp-block.has-warning wp-block-missing {
+	@apply !es-uic-rounded-lg !es-uic-border-zinc-700/15 !es-uic-shadow !es-uic-shadow-zinc-700/10;
+
+	& .block-editor-warning__message {
+		@apply !es-uic-text-zinc-950;
 	}
 }
 
@@ -102,13 +102,9 @@ button.components-toggle-group-control-option-base,
 	@apply !es-uic-rounded;
 }
 
-/* Tweak default inserter position and spacing. */
-.block-list-appender.wp-block > .block-editor-default-block-appender {
-	@apply es-uic-w-fit;
-
-	.block-editor-inserter__toggle {
-		@apply !es-uic-size-9 !es-uic-rounded-md;
-	}
+/* Make default inserter more rounded. */
+.block-editor-inserter__toggle {
+	@apply !es-uic-rounded-md;
 }
 
 /* Unify buttons in top toolbar */
@@ -122,7 +118,7 @@ button.components-toggle-group-control-option-base,
 	}
 }
 
-/* Expand blocks to full-width. */
+/* Allow blocks to expand to full-width. */
 .editor-styles-wrapper .wp-block:not(.editor-post-title, .block-list-appender) {
 	@apply !es-uic-max-w-full;
 }

--- a/lib/wp/gutenberg-overrides.css
+++ b/lib/wp/gutenberg-overrides.css
@@ -67,8 +67,8 @@ button.components-toggle-group-control-option-base,
 }
 
 /* Make block missing message nicer. */
-.block-editor-block-list__block.wp-block.has-warning wp-block-missing {
-	@apply !es-uic-rounded-lg !es-uic-border-zinc-700/15 !es-uic-shadow !es-uic-shadow-zinc-700/10;
+.wp-block-missing div.block-editor-warning {
+	@apply !es-uic-rounded-lg !es-uic-border-zinc-300 !es-uic-bg-zinc-50/75 !es-uic-shadow !es-uic-shadow-zinc-700/20;
 
 	& .block-editor-warning__message {
 		@apply !es-uic-text-zinc-950;


### PR DESCRIPTION
Changes:
- Fixed `clearable` not working in Select components.
- Fixed `Tabs` tab alignment when in horizontal mode.
- `OptionsPanel`, `OptionsPanelSection`, and `OptionsPanelHeader` now support the `hidden` prop.
- Tweaked `OptionsPanelHeader` title font.
- Tweaked some default Gutenberg overrides to do WP 6.6 changes.
- Reverted `position: relative` overlap tweak by @piqusy, as it caused layout issues in some cases. `z-index: 50` should still make it OK.