### PR TITLE
Fix truncate text helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [1.7.1] - 2024-11-14
+- Fixed truncate helper when the input is empty.
+
 ## [1.7.0] - 2024-10-09
 - Updated dependencies.
 - `Repeater`, `Draggable`, `DraggableList` and `ItemCollection` will now behave better when `undefined` is passed as value.
@@ -199,6 +202,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - Initial release
 
 [Unreleased]: https://github.com/infinum/eightshift-ui-components/compare/master...HEAD
+[1.7.1]: https://github.com/infinum/eightshift-ui-components/compare/1.7.0...1.7.1
 [1.7.0]: https://github.com/infinum/eightshift-ui-components/compare/1.6.1...1.7.0
 [1.6.1]: https://github.com/infinum/eightshift-ui-components/compare/1.6.0...1.6.1
 [1.6.0]: https://github.com/infinum/eightshift-ui-components/compare/1.5.1...1.6.0

--- a/lib/utilities/text-helpers.js
+++ b/lib/utilities/text-helpers.js
@@ -21,6 +21,10 @@
  * @preserve
  */
 export const truncateMiddle = (input, maxLength, separator = '...') => {
+	if (!input) {
+		return null;
+	}
+
 	// If the string is shorter than maxLength, just return it.
 	if (input?.length <= maxLength) {
 		return input;
@@ -85,6 +89,10 @@ export const unescapeHTML = (input = '') => new DOMParser().parseFromString(inpu
  * @preserve
  */
 export const truncate = (input, maxLength, separator = '...') => {
+	if (!input) {
+		return null;
+	}
+
 	// If the string is shorter than maxLength, just return it.
 	if (input?.length <= maxLength) {
 		return input;


### PR DESCRIPTION
Reported and related to [[BUG] - LinkSectionEditor component : Deleting URL with X crashes the editor](https://github.com/infinum/eightshift-frontend-libs-tailwind/issues/42)