### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [1.7.2] - 2024-11-14
+- Re-publish of `1.7.1`, as it didn't properly publish.
+
 ## [1.7.1] - 2024-11-14
 - Fixed truncate helper when the input is empty.
 - Added 2 new UI icons and 3 new block icons.
@@ -204,6 +207,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - Initial release
 
 [Unreleased]: https://github.com/infinum/eightshift-ui-components/compare/master...HEAD
+[1.7.2]: https://github.com/infinum/eightshift-ui-components/compare/1.7.1...1.7.2
 [1.7.1]: https://github.com/infinum/eightshift-ui-components/compare/1.7.0...1.7.1
 [1.7.0]: https://github.com/infinum/eightshift-ui-components/compare/1.6.1...1.7.0
 [1.6.1]: https://github.com/infinum/eightshift-ui-components/compare/1.6.0...1.6.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/ui-components",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"type": "module",
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",


### PR DESCRIPTION
NPM had a brain💨 so something didn't publish correctly, just bumping version.
1.7.1 will be deprecated after publishing this.