### PR TITLE
5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [5.0.5] - 2025-06-12
+- Adds a `PortalProvider` component that allows changing the target for transient components like menus, popovers, etc.
+
 ## [5.0.4] - 2025-06-12
 - `Modal` improvements:
   - Now works properly in *controlled* mode (opening controlled by an external variable) - also provides `onOpenChange` so you can update your state when closing is requested
@@ -327,6 +330,7 @@ Co-authored with @piqusy
 - Initial release
 
 [Unreleased]: https://github.com/infinum/eightshift-ui-components/compare/master...HEAD
+[5.0.5]: https://github.com/infinum/eightshift-ui-components/compare/5.0.4...5.0.5
 [5.0.4]: https://github.com/infinum/eightshift-ui-components/compare/5.0.3...5.0.4
 [5.0.3]: https://github.com/infinum/eightshift-ui-components/compare/5.0.2...5.0.3
 [5.0.2]: https://github.com/infinum/eightshift-ui-components/compare/5.0.1...5.0.2

--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -29,6 +29,7 @@ export { MiniResponsive } from './responsive/mini-responsive';
 export { Notice } from './notice/notice';
 export { NumberPicker } from './number-picker/number-picker';
 export { Popover, TriggeredPopover } from './popover/popover';
+export { PortalProvider } from './portal-provider/portal-provider';
 export { RadioButton, RadioButtonGroup } from './radio/radio';
 export { Repeater } from './repeater/repeater';
 export { RepeaterItem } from './repeater/repeater-item';

--- a/lib/components/portal-provider/portal-provider.jsx
+++ b/lib/components/portal-provider/portal-provider.jsx
@@ -1,0 +1,21 @@
+import { UNSAFE_PortalProvider } from 'react-aria';
+
+/**
+ * Component that allows changing the default target for transient components like `Menu`, `Popover`, etc.
+ *
+ * @component
+ * @param {Object} props - Component props.
+ * @param {JSX.Element|null} [props.portalElement] - Element to use as the portal container.
+ *
+ * @returns {JSX.Element} The Menu component.
+ *
+ * @example
+ * <PortalProvider>
+ * 	...
+ * </PortalProvider>
+ *
+ * @preserve
+ */
+export const PortalProvider = ({ children, portalElement }) => {
+	return <UNSAFE_PortalProvider getContainer={() => portalElement}>{children}</UNSAFE_PortalProvider>;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/ui-components",
-	"version": "5.0.4",
+	"version": "5.0.5",
 	"type": "module",
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",


### PR DESCRIPTION
Changes:
- Adds a `PortalProvider` component that allows changing the target for transient components like menus, popovers, etc.